### PR TITLE
Add getter for PR milestone title

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ title | `String` | **true**
 body | `String` | **true**
 locked | `Boolean` | **true** | Accepts `true`, `false` or `'true'`, `'false'`
 milestone | `Integer` | **true**
+milestoneTitle | `String` | false | Title of the milestone set on this pull request
 head | `String` | false | Revision (SHA) of the head commit of this pull request
 headRef | `String` | false | Name of the branch this pull request is created for
 base | `String` | **true** | Name of the base branch in the current repository this pull request targets

--- a/README.md
+++ b/README.md
@@ -173,8 +173,7 @@ issueUrl | `String` | false
 title | `String` | **true**
 body | `String` | **true**
 locked | `Boolean` | **true** | Accepts `true`, `false` or `'true'`, `'false'`
-milestone | `Integer` | **true**
-milestoneTitle | `String` | false | Title of the milestone set on this pull request
+milestone | `Iterable<Milestone>` | false
 head | `String` | false | Revision (SHA) of the head commit of this pull request
 headRef | `String` | false | Name of the branch this pull request is created for
 base | `String` | **true** | Name of the base branch in the current repository this pull request targets

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/MilestoneGroovyObject.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/MilestoneGroovyObject.java
@@ -1,0 +1,74 @@
+package org.jenkinsci.plugins.pipeline.github;
+
+import groovy.lang.GroovyObjectSupport;
+import org.eclipse.egit.github.core.Milestone;
+import org.eclipse.egit.github.core.User;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Groovy object that represents a GitHub Milestone.
+ *
+ * @author jamespullar
+ */
+
+public class MilestoneGroovyObject extends GroovyObjectSupport implements Serializable {
+    private Milestone milestone;
+
+    public MilestoneGroovyObject(final Milestone milestone) {
+        this.milestone = milestone;
+    }
+
+    @Whitelisted
+    public Date getCreatedAt() {
+        return milestone.getCreatedAt();
+    }
+
+    @Whitelisted
+    public Date getDueOn() {
+        return milestone.getDueOn();
+    }
+
+    @Whitelisted
+    public int getClosedIssues() {
+        return milestone.getClosedIssues();
+    }
+
+    @Whitelisted
+    public int getNumber() {
+        return milestone.getNumber();
+    }
+
+    @Whitelisted
+    public int getOpenIssues() {
+        return milestone.getOpenIssues();
+    }
+
+    @Whitelisted
+    public String getDescription() {
+        return milestone.getDescription();
+    }
+
+    @Whitelisted
+    public String getState() {
+        return milestone.getState();
+    }
+
+    @Whitelisted
+    public String getTitle() {
+        return milestone.getTitle();
+    }
+
+    @Whitelisted
+    public String getUrl() {
+        return milestone.getUrl();
+    }
+
+    @Whitelisted
+    public User getCreator() {
+        return milestone.getCreator();
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
@@ -138,6 +138,11 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
     }
 
     @Whitelisted
+    public String getMilestoneTitle() {
+        return pullRequest.getMilestone().getTitle();
+    }
+
+    @Whitelisted
     public String getHead() {
         return pullRequest.getHead().getSha();
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
@@ -133,13 +133,8 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
     }
 
     @Whitelisted
-    public int getMilestone() {
-        return pullRequest.getMilestone().getNumber();
-    }
-
-    @Whitelisted
-    public String getMilestoneTitle() {
-        return pullRequest.getMilestone().getTitle();
+    public MilestoneGroovyObject getMilestone() {
+        return new MilestoneGroovyObject(pullRequest.getMilestone());
     }
 
     @Whitelisted


### PR DESCRIPTION
Currently, only the number from the milestone is available as a getter. Having the title allows for some additional PR verification that would be useful, like ensuring the milestone matches the target branch.