### PR TITLE
mark commentPattern getter public

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/IssueCommentTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/IssueCommentTrigger.java
@@ -65,7 +65,7 @@ public class IssueCommentTrigger extends Trigger<WorkflowJob> {
                 scmHead.getNumber());
     }
 
-    String getCommentPattern() {
+    public String getCommentPattern() {
         return commentPattern;
     }
 


### PR DESCRIPTION
We are seeing errors being generated by pub/sub saying they cannot find the getter for commentPattern.

This is a bit of a stab in the dark, but I figured it can't hurt.

Example trackback:

```
ava.lang.UnsupportedOperationException: no public field 'commentPattern' (or getter method) found in class org.jenkinsci.plugins.pipeline.github.trigger.IssueCommentTrigger
    at org.jenkinsci.plugins.structs.describable.DescribableParameter.getValue(DescribableParameter.java:161)
    at org.jenkinsci.plugins.structs.describable.DescribableParameter.inspect(DescribableParameter.java:142)
    at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate2(DescribableModel.java:555)
    at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate2_(DescribableModel.java:646)
    at org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable.from(UninstantiatedDescribable.java:172)
    at org.jenkinsci.plugins.pipeline.modeldefinition.generator.TriggersDirective$DescriptorImpl.toGroovy(TriggersDirective.java:85)
    at org.jenkinsci.plugins.pipeline.modeldefinition.generator.TriggersDirective$DescriptorImpl.toGroovy(TriggersDirective.java:57)
    at org.jenkinsci.plugins.pipeline.modeldefinition.generator.DirectiveDescriptor.toIndentedGroovy(DirectiveDescriptor.java:57)
    at org.jenkinsci.plugins.pipeline.modeldefinition.generator.DirectiveGenerator.doGenerateDirective(DirectiveGenerator.java:93)
    at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
    at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:343)
    at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:184)
    at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:117)
    at org.kohsuke.stapler.MetaClass$1.doDispatch(MetaClass.java:129)
    at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:58)
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:715)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:845)
    at org.kohsuke.stapler.MetaClass$10.dispatch(MetaClass.java:374)
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:715)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:845)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:649)
    at org.kohsuke.stapler.Stapler.service(Stapler.java:238)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
    at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:841)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1650)
    at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:154)
    at org.jenkinsci.plugins.ssegateway.Endpoint$SSEListenChannelFilter.doFilter(Endpoint.java:225)
    at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:151)
```