### PR TITLE
Add support for creating pull request reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ Returns the merge's SHA/commit id.
 
 > void removeAssignees(List<String> assignees)
 
+#### Reviews
+> void review(String event)
+
+> void review(String event, String body)
+
+> void review(String commitId, String event, String body)
+
 #### Review Comments
 > ReviewComment reviewComment(String commitId, String path, int position, String body)
 
@@ -440,6 +447,18 @@ pullRequest.assignees = ['Data', 'Scotty']
 for (commitFile in pullRequest.files) {
     echo "SHA: ${commitFile.sha} File Name: ${commitFile.filename} Status: ${commitFile.status}"
 }
+```
+
+### Adding a review
+```groovy
+pullRequest.review('APPROVE')
+// or
+pullRequest.review('REQUEST_CHANGES', 'Change is the essential process of all existence.')
+// or
+def commitId = 'SHA of the commit containing the change/file you wish to review' // if unspecified, defaults to the most recent commit
+def event = 'REQUEST_CHANGES' // valid review events: APPROVE, REQUEST_CHANGES, COMMENT
+def body = 'Change is the essential process of all existence.' // body is required when event equals REQUEST_CHANGES or COMMENT
+pullRequest.review(commitId, event, body)
 ```
 
 ### Adding a comment

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/GitHubPipelineGlobalVariables.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/GitHubPipelineGlobalVariables.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.pipeline.github;
 
 import hudson.Extension;
-import hudson.model.Run;;
+import hudson.model.Run;
 import jenkins.scm.api.SCMHead;
 import org.jenkinsci.plugins.github_branch_source.PullRequestSCMHead;
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable;

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
@@ -512,6 +512,13 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
     }
 
     @Whitelisted
+    public void review(final Map<String, Object> params) {
+        review(params.get("commitId") != null ? params.get("commitId").toString() : null,
+               params.get("event") != null ? params.get("event").toString() : null,
+               params.get("body") != null ? params.get("body").toString() : null);
+    }
+
+    @Whitelisted
     public void review(final String commitId, final String event, final String body) {
         if (event != null && (event.equals("REQUEST_CHANGES") || event.equals("COMMENT"))) {
             Objects.requireNonNull(body, "body is a required argument when event equals REQUEST_CHANGES or COMMENT");

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
@@ -502,6 +502,29 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
     }
 
     @Whitelisted
+    public void review(final String event) {
+        review(null, event, null);
+    }
+
+    @Whitelisted
+    public void review(final String event, final String body) {
+        review(null, event, body);
+    }
+
+    @Whitelisted
+    public void review(final String commitId, final String event, final String body) {
+        if (event != null && (event.equals("REQUEST_CHANGES") || event.equals("COMMENT"))) {
+            Objects.requireNonNull(body, "body is a required argument when event equals REQUEST_CHANGES or COMMENT");
+        }
+
+        try {
+            pullRequestService.createReview(base, pullRequestHead.getNumber(), commitId, event, body);
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Whitelisted
     public CommitStatusGroovyObject createStatus(final Map<String, Object> params) {
         Objects.requireNonNull(params.get("status"), "status is a required argument");
 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/client/ExtendedPullRequestService.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/client/ExtendedPullRequestService.java
@@ -183,6 +183,29 @@ public class ExtendedPullRequestService extends PullRequestService {
         return this.createPageIterator(request);
     }
 
+    public void createReview(final IRepositoryIdProvider repository,
+                             final int id,
+                             final String commitId,
+                             final String event,
+                             final String body) throws IOException {
+        if (event != null && (event.equals("REQUEST_CHANGES") || event.equals("COMMENT"))) {
+            Objects.requireNonNull(body, "body is a required argument when event equals REQUEST_CHANGES or COMMENT");
+        }
+
+        String repoId = this.getId(repository);
+        StringBuilder uri = new StringBuilder("/repos");
+        uri.append('/').append(repoId);
+        uri.append("/pulls");
+        uri.append('/').append(id);
+        uri.append("/reviews");
+
+        Map<String, String> params = new HashMap<>();
+        if (commitId != null) params.put("commit_id", commitId);
+        if (body != null) params.put("body", body);
+        if (event != null) params.put("event", event);
+        getClient().post(uri.toString(), params, null);
+    }
+
     public void createReviewRequests(final IRepositoryIdProvider repository,
                                      final int id,
                                      final List<String> reviewers) throws IOException {


### PR DESCRIPTION
- Adds ability to create pull request reviews
- Does not support adding comments at the time of review creation
- Does not return the review object

I didn't see a way to create pull request reviews within the plugin, but maybe I missed it. This PR adds support to create reviews. Although the functionality in this PR is limited, I think it should suffice for MVP and can be further improved in follow on PRs.

Feedback appreciated. Thanks!