### PR TITLE
Fix NPE when accessing a milestone of a PR without a milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ issueUrl | `String` | false
 title | `String` | **true**
 body | `String` | **true**
 locked | `Boolean` | **true** | Accepts `true`, `false` or `'true'`, `'false'`
-milestone | `Integer` | **true**
+milestone | `Integer` | **true** | Milestone Id of this pull request. `-1` means no milestone
 head | `String` | false | Revision (SHA) of the head commit of this pull request
 headRef | `String` | false | Name of the branch this pull request is created for
 base | `String` | **true** | Name of the base branch in the current repository this pull request targets

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
@@ -52,6 +52,8 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
 
     private static final long serialVersionUID = 1L;
 
+    private static final int UNEXISTING_MILESTONE = -1;
+
     private final PullRequestSCMHead pullRequestHead;
     private final RepositoryId base;
     private final RepositoryId head;
@@ -133,7 +135,11 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
 
     @Whitelisted
     public int getMilestone() {
-        return pullRequest.getMilestone().getNumber();
+        if (pullRequest.getMilestone() != null) {
+            return pullRequest.getMilestone().getNumber();
+        } else {
+            return UNEXISTING_MILESTONE;
+        }
     }
 
     @Whitelisted


### PR DESCRIPTION
Current implementation returns an NPE this a quick fix to return `-1` if no milestoned assigned to the pull request.

https://github.com/jenkinsci/pipeline-github-plugin/pull/17 will change this behavior anyway, but since it seems stalled I decided to fix the NPE. If it's required backward compatibility then I could create a new method with the same logic called `getMilestoneId()`, What do you think?