### PR TITLE
Add provision to delete branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,9 @@ Returns the merge's SHA/commit id.
 
 > void deleteReviewRequests(List<String> reviewers)
 
+### Delete Branch
+> void deleteBranch()
+
 #### Misc
 > void setCredentials(String userName, String password)
 
@@ -583,4 +586,10 @@ pullRequest.createReviewRequests(['Spock', 'McCoy'])
 ### Deleting requested reviewers
 ```groovy
 pullRequest.deleteReviewRequests(['McCoy'])
+```
+
+### Deleting a branch of the pull request after Merging the pull request
+```groovy
+pullRequest.merge(pullRequest.title)
+pullRequest.deleteBranch()
 ```

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
@@ -740,4 +740,13 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
     public void setCredentials(final String userName, final String password) {
         getGitHubClient().setCredentials(userName, password);
     }
+
+    @Whitelisted
+    public void deleteBranch(){
+        try {
+            getPullRequestService().deleteBranch(base,pullRequest.getBranchReference());
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
@@ -740,13 +740,4 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
     public void setCredentials(final String userName, final String password) {
         getGitHubClient().setCredentials(userName, password);
     }
-
-    @Whitelisted
-    public void deleteBranch(){
-        try {
-            getPullRequestService().deleteBranch(base,pullRequest.getBranchReference());
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
 }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/client/ExtendedPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/client/ExtendedPullRequest.java
@@ -45,8 +45,4 @@ public class ExtendedPullRequest extends PullRequest {
     public void setMaintainerCanModify(final Boolean maintainerCanModify) {
         this.maintainerCanModify = maintainerCanModify;
     }
-
-    public String getBranchReference(){
-        return this.getHead().getRef();
-    }
 }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/client/ExtendedPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/client/ExtendedPullRequest.java
@@ -45,4 +45,8 @@ public class ExtendedPullRequest extends PullRequest {
     public void setMaintainerCanModify(final Boolean maintainerCanModify) {
         this.maintainerCanModify = maintainerCanModify;
     }
+
+    public String getBranchReference(){
+        return this.getHead().getRef();
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/client/ExtendedPullRequestService.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/client/ExtendedPullRequestService.java
@@ -224,18 +224,4 @@ public class ExtendedPullRequestService extends PullRequestService {
         params.put("reviewers", reviewers);
         getClient().delete(uri.toString(), params);
     }
-
-    public void deleteBranch(final IRepositoryIdProvider repository,
-        final String branchReference
-    ) throws IOException {
-        String repoId = this.getId(repository);
-        StringBuilder uri = new StringBuilder("/repos");
-        uri.append('/').append(repoId);
-        uri.append("/git");
-        uri.append("/refs");
-        uri.append("/heads");
-        uri.append('/');
-        uri.append(branchReference);
-        getClient().delete(uri.toString());
-    }
 }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/client/ExtendedPullRequestService.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/client/ExtendedPullRequestService.java
@@ -224,4 +224,18 @@ public class ExtendedPullRequestService extends PullRequestService {
         params.put("reviewers", reviewers);
         getClient().delete(uri.toString(), params);
     }
+
+    public void deleteBranch(final IRepositoryIdProvider repository,
+        final String branchReference
+    ) throws IOException {
+        String repoId = this.getId(repository);
+        StringBuilder uri = new StringBuilder("/repos");
+        uri.append('/').append(repoId);
+        uri.append("/git");
+        uri.append("/refs");
+        uri.append("/heads");
+        uri.append('/');
+        uri.append(branchReference);
+        getClient().delete(uri.toString());
+    }
 }


### PR DESCRIPTION
*motivation*

- github enterprise being used at the moment does not give provision: https://help.github.com/en/github/administering-a-repository/managing-the-automatic-deletion-of-branches
- I want to be able to delete the branch after the PR has been merged

*Changes*

- `https://developer.github.com/v3/pulls/#get-a-single-pull-request` response is populated in `org.eclipse.egit.github.core.PullRequest`
- response has reference to branch in Object `org.eclipse.egit.github.core.PullRequest#head` - `org.eclipse.egit.github.core.PullRequestMarker#ref`
- this reference is needed to perform deletion : `https://developer.github.com/v3/git/refs/#delete-a-reference`