### PR TITLE
Add support for team reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,16 @@ pullRequest.createReviewRequests(['Spock', 'McCoy'])
 pullRequest.deleteReviewRequests(['McCoy'])
 ```
 
+### Requesting team reviewers
+```groovy
+pullRequest.createTeamReviewRequests(['justice-league'])
+```
+
+### Deleting requested team reviewers
+```groovy
+pullRequest.deleteTeamReviewRequests(['justice-league'])
+```
+
 ### Deleting a branch of the pull request after Merging the pull request
 ```groovy
 pullRequest.merge(pullRequest.title)

--- a/README.md
+++ b/README.md
@@ -256,9 +256,17 @@ Returns the merge's SHA/commit id.
 > void deleteComment(long commentId)
 
 ### Requested Reviewers
+> Iterable<String> getRequestedReviewers<>()
+
 > void createReviewRequests(List<String> reviewers)
 
+> void createTeamReviewRequests(List<String> teams)
+
+> Iterable<String> getRequestedTeamReviewers<>()
+
 > void deleteReviewRequests(List<String> reviewers)
+
+> void deleteTeamReviewRequests(List<String> teams)
 
 ### Delete Branch
 > void deleteBranch()

--- a/README.md
+++ b/README.md
@@ -586,6 +586,13 @@ for (requestedReviewer in pullRequest.requestedReviewers) {
 }
 ```
 
+### Listing a Pull Request's requested team reviewers
+```groovy
+for (requestedTeamReviewer in pullRequest.requestedTeamReviewers) {
+  echo "${requestedTeamReviewer} was requested to review this Pull Request"
+}
+```
+
 ### Listing a Pull Request's reviews
 ```groovy
 for (review in pullRequest.reviews) {

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
@@ -10,6 +10,7 @@ import org.eclipse.egit.github.core.Label;
 import org.eclipse.egit.github.core.Milestone;
 import org.eclipse.egit.github.core.PullRequestMarker;
 import org.eclipse.egit.github.core.RepositoryId;
+import org.eclipse.egit.github.core.Team;
 import org.eclipse.egit.github.core.User;
 import org.jenkinsci.plugins.github_branch_source.PullRequestSCMHead;
 import org.jenkinsci.plugins.pipeline.github.client.ExtendedCommitComment;
@@ -293,6 +294,17 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
     }
 
     @Whitelisted
+    public Iterable<String> getRequestedTeamReviewers() {
+        Stream<String> stream = StreamSupport
+                .stream(getPullRequestService().pageRequestedTeamReviewers(base, pullRequest.getNumber())
+                        .spliterator(), false)
+                .flatMap(Collection::stream)
+                .map(Team::getName);
+
+        return stream::iterator;
+    }
+
+    @Whitelisted
     public Iterable<ReviewGroovyObject> getReviews() {
         Stream<ReviewGroovyObject> stream = StreamSupport
             .stream(getPullRequestService().pageReviews(base, pullRequest.getNumber())
@@ -485,7 +497,7 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
     public void createReviewRequests(final List<String> reviewers) {
         Objects.requireNonNull(reviewers, "reviewers cannot be null");
         try {
-            getPullRequestService().createReviewRequests(base, pullRequest.getNumber(), reviewers);
+            getPullRequestService().createReviewRequests(base, pullRequest.getNumber(), reviewers, null);
         } catch (final IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -501,7 +513,40 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
     public void deleteReviewRequests(final List<String> reviewers) {
         Objects.requireNonNull(reviewers, "reviewers cannot be null");
         try {
-            getPullRequestService().deleteReviewRequests(base, pullRequest.getNumber(), reviewers);
+            getPullRequestService().deleteReviewRequests(base, pullRequest.getNumber(), reviewers, null);
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+
+    @Whitelisted
+    public void createTeamReviewRequest(final String team) {
+        Objects.requireNonNull(team, "team cannot be null");
+        createTeamReviewRequests(Collections.singletonList(team));
+    }
+
+    @Whitelisted
+    public void createTeamReviewRequests(final List<String> teams) {
+        Objects.requireNonNull(teams, "teams cannot be null");
+        try {
+            getPullRequestService().createReviewRequests(base, pullRequest.getNumber(), null, teams);
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Whitelisted
+    public void deleteTeamReviewRequest(final String team) {
+        Objects.requireNonNull(team, "team cannot be null");
+        deleteTeamReviewRequests(Collections.singletonList(team));
+    }
+
+    @Whitelisted
+    public void deleteTeamReviewRequests(final List<String> teams) {
+        Objects.requireNonNull(teams, "teams cannot be null");
+        try {
+            getPullRequestService().deleteReviewRequests(base, pullRequest.getNumber(), null, teams);
         } catch (final IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
Adds support for listing / adding / deleting requests for team reviewers.

These are done via the same Github API calls as individual reviewers, but I added them as parallel methods in the Jenkins API to maintain backwards compatibility. The service level is consistent with the Github API