### PR TITLE
Read GitHub pipeline docs from GitHub for plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <name>Pipeline: GitHub</name>
     <description>Pipeline GitHub Support</description>
-    <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Github+Plugin</url>
+    <url>https://github.com/jenkinsci/pipeline-github-plugin</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
## Use GitHub for [plugins.jenkins.io docs](https://plugins.jenkins.io/pipeline-github/)

See [documenting plugins](https://jenkins.io/doc/developer/publishing/documentation/#documenting-plugins) for more detailed instructions on how the conversion uses either [README.md](https://github.com/jenkinsci/pipeline-github-plugin/blob/master/README.md) or README.adoc to provide detailed plugin documentation to plugins.jenkins.io.  The README is excellent in this repository and provides great documentation for the plugin.  Let's show it on [plugins.jenkins.io](https://plugins.jenkins.io/pipeline-github/).  Note that plugins.jenkins.io reads the pom.xml published with the released plugin.  In order to update plugins.jenkins.io, this change needs to be merged and a new version of the plugin needs to be released.

See also [documenting plugins blog post](https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/).

See also [git plugin documentation](https://plugins.jenkins.io/git/) as an example (can automatically maintain the table of contents in documentation if you choose to switch the docs from markdown to asciidoc, but markdown works great just as this plugin is already documented).