### PR TITLE
Add ability to retrieve draft state of a PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ merged | `Boolean` | false
 mergeable | `Boolean` | false
 mergeCommitSha | `String` | false
 maintainerCanModify | `Boolean` | **true** | Accepts `true`, `false` or `'true'`, `'false'`
+draft | `Boolean` | false
 
 
 ### Methods

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
@@ -178,6 +178,11 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
     }
 
     @Whitelisted
+    public boolean isDraft() {
+        return pullRequest.isDraft();
+    }
+
+    @Whitelisted
     public MilestoneGroovyObject getMilestone() {
         return Optional.ofNullable(pullRequest.getMilestone())
                 .map(Milestone::getNumber)

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/client/ExtendedPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/client/ExtendedPullRequest.java
@@ -11,6 +11,7 @@ public class ExtendedPullRequest extends PullRequest {
 
     private User closedBy;
     private boolean locked;
+    private boolean draft;
     private String mergeCommitSha;
     private Boolean maintainerCanModify;
 
@@ -28,6 +29,14 @@ public class ExtendedPullRequest extends PullRequest {
 
     public void setLocked(final boolean locked) {
         this.locked = locked;
+    }
+
+    public boolean isDraft() {
+        return draft;
+    }
+
+    public void setDraft(final boolean draft) {
+        this.draft = draft;
     }
 
     public String getMergeCommitSha() {


### PR DESCRIPTION
Hi there! 👋

We have a use-case where we want to only run certain pipelines if the PR in question is not a draft.

I didn't find a way to test my changes, but they seemed to be in line with what other similar PR's have done. 

Looking forward to any comments/critiques. 