### PR TITLE
Pipeline trigger for Pull Request reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ If you plan to use this plugin to add/modify/remove comments, labels, commit sta
 
 This plugin adds the following pipeline triggers
 
+* issueCommentTrigger
+* pullRequestReview
+
 ## issueCommentTrigger
 
 ### Requirements
@@ -119,6 +122,60 @@ The GitHub comment and author that triggered the build are exposed as environmen
 
 * `GITHUB_COMMENT`
 * `GITHUB_COMMENT_AUTHOR`
+
+## pullRequestReview
+
+### Parameters
+
+- `reviewStates` (__Optional__) - A Java array of the PR review states you wish to trigger the build with. If not specified it will trigger for any review state. Possible states are `pending, approved, changes_requested, commented, dismissed`
+
+### Usage
+
+#### Scripted Pipeline:
+```groovy
+properties([
+    pipelineTriggers([
+      pullRequestReview(reviewStates: ['approved'])
+    ])
+])
+```
+
+#### Declarative Pipeline:
+```groovy
+pipeline {
+    triggers {
+      pullRequestReview(reviewStates: ['approved'])
+    }
+}
+```
+
+#### Detecting whether a build was started by the trigger in a script:
+
+Note that the following uses `currentBuild.rawBuild` and should therefore only
+be done in a `@NonCPS` context. See [the workflow-cps-plugin Technical Design
+](https://github.com/jenkinsci/workflow-cps-plugin/blob/master/README.md#technical-design)
+for more information.
+
+```groovy
+def triggerCause = currentBuild.rawBuild.getCause(org.jenkinsci.plugins.pipeline.github.trigger.PullRequestReviewCause)
+
+if (triggerCause) {
+    echo("Build was started by ${triggerCause.userLogin}, who reviewed the PR: " +
+         "\"${triggerCause.state}\", which matches one of " +
+         "\"${triggerCause.reviewStates}\" trigger pattern.")
+} else {
+    echo('Build was not started by a trigger')
+}
+```
+
+#### Environment variables
+
+The GitHub review comment and author that triggered the build are exposed as environment variables (from version > 2.8).
+
+* `GITHUB_REVIEW_COMMENT`
+* `GITHUB_REVIEW_AUTHOR`
+* `GITHUB_REVIEW_STATE`
+
 
 # Global Variables
 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/PullRequestReviewCause.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/PullRequestReviewCause.java
@@ -1,0 +1,49 @@
+package org.jenkinsci.plugins.pipeline.github.trigger;
+
+import hudson.model.Cause;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+
+/**
+ * Represents the user who reviewed the PR that triggered the build.
+ *
+ * @author Aaron Walker
+ */
+public class PullRequestReviewCause extends Cause {
+
+  private final String userLogin;
+  private final String comment;
+  private final String state;
+  private final String[] reviewStates;
+
+  public PullRequestReviewCause(final String userLogin, final String state, final String comment, final String[] reviewStates) {
+    this.userLogin = userLogin;
+    this.state = state;
+    this.comment = comment;
+    this.reviewStates = reviewStates;
+  }
+
+  @Whitelisted
+  public String getUserLogin() {
+      return userLogin;
+  }
+
+  @Whitelisted
+  public String getComment() {
+      return comment;
+  }
+  
+  @Whitelisted
+  public String getState() {
+      return state;
+  }
+
+  @Whitelisted
+  public String[] getReviewStates() {
+      return reviewStates;
+  }
+
+  @Override
+  public String getShortDescription() {
+      return String.format("%s reviewed: %s", userLogin, state);
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/PullRequestReviewTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/PullRequestReviewTrigger.java
@@ -1,0 +1,107 @@
+package org.jenkinsci.plugins.pipeline.github.trigger;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.Extension;
+import hudson.model.Item;
+import hudson.triggers.Trigger;
+import hudson.triggers.TriggerDescriptor;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMSource;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
+import org.jenkinsci.plugins.github_branch_source.PullRequestSCMHead;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+/**
+ * An PullRequestApprovalTrigger, to be used from pipeline scripts only.
+ *
+ * This trigger will not show up on a jobs configuration page.
+ *
+ * @author Aaron Walker
+ * @see org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty
+ */
+public class PullRequestReviewTrigger  extends Trigger<WorkflowJob> {
+  private static final Logger LOG = LoggerFactory.getLogger(PullRequestReviewTrigger.class);
+
+  private String[] reviewStates = null;
+
+  @DataBoundConstructor
+  public PullRequestReviewTrigger() {}
+
+  public String[] getReviewStates() {
+      return reviewStates;
+  }
+
+  @DataBoundSetter
+  public void setReviewStates(@Nonnull final String [] reviewStates) {
+      this.reviewStates = reviewStates;
+  }
+
+  @Override
+  public void start(final WorkflowJob project, final boolean newInstance) {
+      super.start(project, newInstance);
+      // we only care about pull requests
+      if (SCMHead.HeadByItem.findHead(project) instanceof PullRequestSCMHead) {
+          DescriptorImpl.jobs
+                  .computeIfAbsent(getKey(project), key -> new HashSet<>())
+                  .add(project);
+      }
+  }
+
+  @Override
+  public void stop() {
+      if (SCMHead.HeadByItem.findHead(job) instanceof PullRequestSCMHead) {
+          DescriptorImpl.jobs.getOrDefault(getKey(job), Collections.emptySet())
+                  .remove(job);
+      }
+  }
+
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+  private String getKey(final WorkflowJob project) {
+      final GitHubSCMSource scmSource = (GitHubSCMSource) SCMSource.SourceByItem.findSource(project);
+      final PullRequestSCMHead scmHead = (PullRequestSCMHead) SCMHead.HeadByItem.findHead(project);
+
+      return String.format("%s/%s/%d",
+              scmSource.getRepoOwner(),
+              scmSource.getRepository(),
+              scmHead.getNumber());
+  }
+
+  boolean matches(final String reviewState) {
+    if(reviewStates == null) {
+        return true; //defaults to trigger on any review state
+    } else {
+        List<String> list = Arrays.asList(reviewStates);
+        return list.contains(reviewState);
+    }
+  }
+
+  @Symbol("pullRequestReview")
+  @Extension
+  public static class DescriptorImpl extends TriggerDescriptor {
+      private transient static final Map<String, Set<WorkflowJob>> jobs = new ConcurrentHashMap<>();
+
+      @Override
+      public boolean isApplicable(final Item item) {
+          return false; // this is not configurable from the ui.
+      }
+
+      public Set<WorkflowJob> getJobs(final String key) {
+          return jobs.getOrDefault(key, Collections.emptySet());
+      }
+  }
+}


### PR DESCRIPTION
This PR adds a new trigger called pullRequestReview which allows for triggering a build based on the review state of the PR.

It adds the some environment variables to the pipeline with the details of the review that triggered the build but the full review history is accessible via the the pullRequest global variable.

I have tested this pretty extensively and currently have this deployed and working in a number of Jenkins environments

@aaronjwhiteside any comments/critiques welcome.