### PR TITLE
use proxy env PROXY_HOST and PROXY_PORT automatically if defined

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>org.eclipse.mylyn.github</groupId>
             <artifactId>org.eclipse.egit.github.core</artifactId>
-            <version>5.2.0.201812061821-r</version>
+            <version>5.7.0.202001151323-m1</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/GitHubHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/GitHubHelper.java
@@ -18,6 +18,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -60,6 +63,13 @@ public class GitHubHelper {
 
             URI uri = URI.create(gitHubSource.getApiUri());
             ExtendedGitHubClient client = new ExtendedGitHubClient(uri.getHost(), uri.getPort(), uri.getScheme());
+
+            String proxyHost = System.getenv("PROXY_HOST");
+            String proxyPort = System.getenv("PROXY_PORT");
+            if (proxyHost != null && proxyPort != null) {
+                SocketAddress addr = new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort));
+                client.setProxy(new Proxy(Proxy.Type.HTTP, addr));
+            }
 
             // configure credentials
             if (gitHubSource.getCredentialsId() != null) {


### PR DESCRIPTION
With this change, we will automatically use the `PROXY_HOST` and `PROXY_PORT` environment variables, if defined.
This is useful, in any environment, which requires a HTTP Proxy to communicate to the other endpoints. I built it locally, and it works for me.

Resolves https://github.com/jenkinsci/pipeline-github-plugin/issues/66

What do you think about it?