### PR TITLE
Include line in review comment API calls

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
@@ -675,7 +675,7 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
     @Whitelisted
     public ReviewCommentGroovyObject reviewComment(final String commitId,
                                                    final String path,
-                                                   final int position,
+                                                   final int line,
                                                    final String body) {
         Objects.requireNonNull(commitId, "commitId is a required argument");
         Objects.requireNonNull(path, "path is a required argument");
@@ -684,7 +684,7 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
         ExtendedCommitComment comment = new ExtendedCommitComment();
         comment.setCommitId(commitId);
         comment.setPath(path);
-        comment.setPosition(position);
+        comment.setLine(line);
         comment.setBody(body);
         try {
             return new ReviewCommentGroovyObject(


### PR DESCRIPTION
copied [@mollstam](https://github.com/mollstam) [PR](https://github.com/Tocaboca/pipeline-github-plugin/pull/1) to fix https://github.com/jenkinsci/pipeline-github-plugin/issues/88

This change sets `line` instead of `position` when adding review comments through `pullRequest.reviewComment(...)` to not have the API call fail with an error.

Seems like GitHub made a change to their API, or I assume this code at one point worked at least, there's an issue upstream about this: [jenkinsci#88](https://github.com/jenkinsci/pipeline-github-plugin/issues/88)