### PR TITLE
fix(triggers): handles github repos with mixed case org and repo names

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/IssueCommentTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/IssueCommentTrigger.java
@@ -68,7 +68,7 @@ public class IssueCommentTrigger extends Trigger<WorkflowJob> {
         return String.format("%s/%s/%d",
                 scmSource.getRepoOwner(),
                 scmSource.getRepository(),
-                scmHead.getNumber());
+                scmHead.getNumber()).toLowerCase();
     }
 
     public String getCommentPattern() {
@@ -92,7 +92,7 @@ public class IssueCommentTrigger extends Trigger<WorkflowJob> {
         }
 
         public Set<WorkflowJob> getJobs(final String key) {
-            return jobs.getOrDefault(key, Collections.emptySet());
+            return jobs.getOrDefault(key.toLowerCase(), Collections.emptySet());
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/PullRequestReviewTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/PullRequestReviewTrigger.java
@@ -78,7 +78,7 @@ public class PullRequestReviewTrigger  extends Trigger<WorkflowJob> {
       return String.format("%s/%s/%d",
               scmSource.getRepoOwner(),
               scmSource.getRepository(),
-              scmHead.getNumber());
+              scmHead.getNumber()).toLowerCase();
   }
 
   boolean matches(final String reviewState) {
@@ -101,7 +101,7 @@ public class PullRequestReviewTrigger  extends Trigger<WorkflowJob> {
       }
 
       public Set<WorkflowJob> getJobs(final String key) {
-          return jobs.getOrDefault(key, Collections.emptySet());
+          return jobs.getOrDefault(key.toLowerCase(), Collections.emptySet());
       }
   }
 }


### PR DESCRIPTION
It's possible to create a pipeline job using github url that is all lowercase even if on github the org or repo is actually mixed case. Github will include org and repo name using the mixed case version in any events it sends and therefore when the jobs that need to be triggered are looked up they don't match.

I think its better to ignore the case when looking up which jobs to trigger since github really ignores the org/owner case anyway