### PR TITLE
Added Label added trigger to plugin

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/GitHubEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/GitHubEventSubscriber.java
@@ -75,6 +75,8 @@ public class GitHubEventSubscriber extends GHEventsSubscriber {
             case ISSUE_COMMENT:
                 handleIssueComment(event);
                 break;
+            case PULL_REQUEST:
+                handleLabelEvent(event);
             case PULL_REQUEST_REVIEW:
                 handlePullRequestReview(event);
                 break;
@@ -83,6 +85,72 @@ public class GitHubEventSubscriber extends GHEventsSubscriber {
         }
     }
 
+    private void handleLabelEvent(final GHSubscriberEvent event) {
+        switch (event.getType()){
+            case CREATED:
+            case UPDATED:
+                break;
+            default:
+                return;
+        }
+        final GHEventPayload.PullRequest prEvent;
+        try {
+            prEvent = GitHub.offline()
+                    .parseEventPayload(new StringReader(event.getPayload()), GHEventPayload.PullRequest.class);
+        } catch (final IOException e) {
+            LOG.error("Unable to parse the payload of GHSubscriberEvent: {}", event, e);
+            return;
+        }
+        switch (prEvent.getAction()) {
+            case "labeled":
+                break;
+            default:
+                LOG.debug("Ignoring PR: {} event with Action: {}",
+                        prEvent.getNumber(), prEvent.getAction());
+                return;
+        }
+        // create key for this comment's PR
+        final String key = String.format("%s/%s/%d",
+                prEvent.getRepository().getOwnerName(),
+                prEvent.getRepository().getName(),
+                prEvent.getNumber());
+                // lookup trigger
+        final LabelAddedTrigger.DescriptorImpl triggerDescriptor = (LabelAddedTrigger.DescriptorImpl) Jenkins.get()
+                .getDescriptor(LabelAddedTrigger.class);
+        if (triggerDescriptor == null) {
+            LOG.error("Unable to find the LabelAddedTrigger Trigger, this shouldn't happen.");
+            return;
+        }
+        // create values for the action if a new job is triggered afterward
+        ArrayList<ParameterValue> values = new ArrayList<ParameterValue>();
+        String labelName = prEvent.getLabel().getName();
+        values.add(new StringParameterValue("GITHUB_LABEL_ADDED", String.valueOf(labelName)));
+        // lookup jobs
+        for (final WorkflowJob job : triggerDescriptor.getJobs(key)) {
+            // find triggers
+            final List<LabelAddedTrigger> matchingTriggers = job.getTriggersJobProperty()
+                    .getTriggers()
+                    .stream()
+                    .filter(LabelAddedTrigger.class::isInstance)
+                    .map(LabelAddedTrigger.class::cast)
+                    .filter(labelTrigger -> labelAddedMatches(labelTrigger, labelName, job))
+                    .collect(Collectors.toList());
+
+            job.scheduleBuild2(
+                Jenkins.getInstance().getQuietPeriod(),
+                new CauseAction(
+                    new LabelAddedCause(
+                        prEvent.getSender().getLogin(),
+                        labelName
+                    )
+                ),
+                new GitHubEnvironmentVariablesAction(values)
+            );
+        }
+    }
+    private boolean labelAddedMatches (final LabelAddedTrigger trigger,final String labelName,final WorkflowJob job ){
+        return false;
+    }
     private void handleIssueComment(final GHSubscriberEvent event) {
         // we only care about created or updated events
         switch (event.getType()) {
@@ -141,7 +209,7 @@ public class GitHubEventSubscriber extends GHEventsSubscriber {
                     .stream()
                     .filter(IssueCommentTrigger.class::isInstance)
                     .map(IssueCommentTrigger.class::cast)
-                    .filter(t -> triggerMatches(t, issueCommentEvent.getComment(), job))
+                    .filter(t -> commentTriggerMatches(t, issueCommentEvent.getComment(), job))
                     .collect(Collectors.toList());
 
             // check if they have authorization
@@ -175,7 +243,7 @@ public class GitHubEventSubscriber extends GHEventsSubscriber {
         return GitHubHelper.isAuthorized(job, commentAuthor);
     }
 
-    private boolean triggerMatches(final IssueCommentTrigger trigger,
+    private boolean commentTriggerMatches(final IssueCommentTrigger trigger,
                                    final GHIssueComment issueComment,
                                    final WorkflowJob job) {
         if (trigger.matchesComment(issueComment.getBody())) {
@@ -248,7 +316,7 @@ public class GitHubEventSubscriber extends GHEventsSubscriber {
                     .stream()
                     .filter(PullRequestReviewTrigger.class::isInstance)
                     .map(PullRequestReviewTrigger.class::cast)
-                    .filter(t -> triggerMatches(t, pullRequestReview.getReview(), job))
+                    .filter(t -> commentTriggerMatches(t, pullRequestReview.getReview(), job))
                     .collect(Collectors.toList());
 
             // check if they have authorization
@@ -279,7 +347,7 @@ public class GitHubEventSubscriber extends GHEventsSubscriber {
     }
 
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
-    private boolean triggerMatches(final PullRequestReviewTrigger trigger,
+    private boolean commentTriggerMatches(final PullRequestReviewTrigger trigger,
                                    final GHPullRequestReview review,
                                    final WorkflowJob job) {
         if (trigger.matches(review.getState().name().toLowerCase())) {

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/GitHubEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/GitHubEventSubscriber.java
@@ -139,6 +139,7 @@ public class GitHubEventSubscriber extends GHEventsSubscriber {
                     .collect(Collectors.toList());
 
             if (matchingTriggers.size() == 0) {
+                LOG.debug("No labels match the ones attached to the trigger");
                 break;
             }
             job.scheduleBuild2(
@@ -154,7 +155,7 @@ public class GitHubEventSubscriber extends GHEventsSubscriber {
         }
     }
     private boolean labelAddedMatches(final LabelAddedTrigger trigger,final String labelName,final WorkflowJob job ){
-        boolean matches = trigger.getLabelTrigger().equalsIgnoreCase(labelName);
+        boolean matches = trigger.matchesLabel(labelName);
         if (matches) {
             LOG.debug("Job: {}, labelName: {}, the label did matched the triggerLabel: {}",
                 job.getFullName(), labelName, trigger.getLabelTrigger());
@@ -264,10 +265,10 @@ public class GitHubEventSubscriber extends GHEventsSubscriber {
             LOG.debug("Job: {}, IssueComment: {} matched Pattern: {}",
                     job.getFullName(), issueComment, trigger.getCommentPattern());
             return true;
-        } else {
-            LOG.debug("Job: {}, IssueComment: {}, the comment did not match Pattern: {}",
-                    job.getFullName(), issueComment, trigger.getCommentPattern());
         }
+        LOG.debug("Job: {}, IssueComment: {}, the comment did not match Pattern: {}",
+                job.getFullName(), issueComment, trigger.getCommentPattern());
+    
         return false;
     }
 
@@ -381,6 +382,7 @@ public class GitHubEventSubscriber extends GHEventsSubscriber {
 //        events.add(GHEvent.PULL_REQUEST_REVIEW_COMMENT);
 //        events.add(GHEvent.COMMIT_COMMENT);
         events.add(GHEvent.ISSUE_COMMENT);
+        events.add(GHEvent.PULL_REQUEST);
         events.add(GHEvent.PULL_REQUEST_REVIEW);
         return Collections.unmodifiableSet(events);
     }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/GitHubEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/GitHubEventSubscriber.java
@@ -77,6 +77,7 @@ public class GitHubEventSubscriber extends GHEventsSubscriber {
                 break;
             case PULL_REQUEST:
                 handleLabelEvent(event);
+                break;
             case PULL_REQUEST_REVIEW:
                 handlePullRequestReview(event);
                 break;

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/LabelAddedCause.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/LabelAddedCause.java
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.pipeline.github.trigger;
+
+import hudson.model.Cause;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import java.util.List;
+
+/**
+ * Represents the user who authored the comment that triggered the build.
+ *
+ * @author Aaron Whiteside
+ */
+public class LabelAddedCause extends Cause {
+    private final String userLogin;
+    private final String labelAdded;
+
+
+    public LabelAddedCause(final String userLogin, final String label) {
+        this.userLogin = userLogin;
+        this.labelAdded = label;
+    }
+
+    @Whitelisted
+    public String getUserLogin() {
+        return userLogin;
+    }
+
+    @Whitelisted
+    public String getLabelAdded() {
+        return labelAdded;
+    }
+
+    @Override
+    public String getShortDescription() {
+        return String.format("%s added label %s", userLogin, labelAdded);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/LabelAddedTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/LabelAddedTrigger.java
@@ -1,0 +1,96 @@
+package org.jenkinsci.plugins.pipeline.github.trigger;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.Extension;
+import hudson.model.Item;
+import hudson.triggers.Trigger;
+import hudson.triggers.TriggerDescriptor;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMSource;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
+import org.jenkinsci.plugins.github_branch_source.PullRequestSCMHead;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * An LabelAddedTrigger, to be used from pipeline scripts only.
+ *
+ * This trigger will not show up on a jobs configuration page.
+ *
+ * @author Joaquín Fernández Campo
+ * @see org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty
+ */
+public class LabelAddedTrigger extends Trigger<WorkflowJob> {
+    private static final Logger LOG = LoggerFactory.getLogger(LabelAddedTrigger.class);
+
+    private final String labelTrigger;
+
+    @DataBoundConstructor
+    public LabelAddedTrigger(@Nonnull final String labelTrigger) {
+        this.labelTrigger = labelTrigger;
+    }
+
+    @Override
+    public void start(final WorkflowJob project, final boolean newInstance) {
+        super.start(project, newInstance);
+        // we only care about pull requests
+        if (SCMHead.HeadByItem.findHead(project) instanceof PullRequestSCMHead) {
+            DescriptorImpl.jobs
+                    .computeIfAbsent(getKey(project), key -> new HashSet<>())
+                    .add(project);
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (SCMHead.HeadByItem.findHead(job) instanceof PullRequestSCMHead) {
+            DescriptorImpl.jobs.getOrDefault(getKey(job), Collections.emptySet())
+                    .remove(job);
+        }
+    }
+
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+    private String getKey(final WorkflowJob project) {
+        final GitHubSCMSource scmSource = (GitHubSCMSource) SCMSource.SourceByItem.findSource(project);
+        final PullRequestSCMHead scmHead = (PullRequestSCMHead) SCMHead.HeadByItem.findHead(project);
+
+        return String.format("%s/%s/%d",
+                scmSource.getRepoOwner(),
+                scmSource.getRepository(),
+                scmHead.getNumber()).toLowerCase();
+    }
+
+    public String getLabelTrigger() {
+        return labelTrigger;
+    }
+
+    boolean labelMatches(final String labelAdded) {
+        return labelTrigger.equalsIgnoreCase(labelAdded);
+    }
+
+    @Symbol("LabelAddedTrigger")
+    @Extension
+    public static class DescriptorImpl extends TriggerDescriptor {
+        private transient static final Map<String, Set<WorkflowJob>> jobs = new ConcurrentHashMap<>();
+
+        @Override
+        public boolean isApplicable(final Item item) {
+            return false; // this is not configurable from the ui.
+        }
+
+        public Set<WorkflowJob> getJobs(final String key) {
+            return jobs.getOrDefault(key.toLowerCase(), Collections.emptySet());
+        }
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/LabelAddedTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/LabelAddedTrigger.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 
 /**
  * An LabelAddedTrigger, to be used from pipeline scripts only.
@@ -33,11 +34,11 @@ import java.util.concurrent.ConcurrentHashMap;
 public class LabelAddedTrigger extends Trigger<WorkflowJob> {
     private static final Logger LOG = LoggerFactory.getLogger(LabelAddedTrigger.class);
 
-    private final String labelTrigger;
+    private final String labelTriggerPattern;
 
     @DataBoundConstructor
-    public LabelAddedTrigger(@Nonnull final String labelTrigger) {
-        this.labelTrigger = labelTrigger;
+    public LabelAddedTrigger(@Nonnull final String labelTriggerPattern) {
+        this.labelTriggerPattern = labelTriggerPattern;
     }
 
     @Override
@@ -71,7 +72,12 @@ public class LabelAddedTrigger extends Trigger<WorkflowJob> {
     }
 
     public String getLabelTrigger() {
-        return labelTrigger;
+        return labelTriggerPattern;
+    }
+    boolean matchesLabel(final String label) {
+        return Pattern.compile(labelTriggerPattern)
+                .matcher(label)
+                .matches();
     }
 
     @Symbol("labelAddedTrigger")

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/LabelAddedTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/LabelAddedTrigger.java
@@ -74,11 +74,7 @@ public class LabelAddedTrigger extends Trigger<WorkflowJob> {
         return labelTrigger;
     }
 
-    boolean labelMatches(final String labelAdded) {
-        return labelTrigger.equalsIgnoreCase(labelAdded);
-    }
-
-    @Symbol("LabelAddedTrigger")
+    @Symbol("labelAddedTrigger")
     @Extension
     public static class DescriptorImpl extends TriggerDescriptor {
         private transient static final Map<String, Set<WorkflowJob>> jobs = new ConcurrentHashMap<>();


### PR DESCRIPTION
Added support to define a `labelAddedTrigger` (this is something we need to support), this could be generalized to _any_ label event if it was required, but I feel like this is the most common usecase. 

~~Potentially this can be extended to support a regex instead of a list (I'm open to do that as it seems simple enough).~~ This is now supported.


Opening the PR early in order to get feedback and I know that there's a CI for PRs that generates artifacts, so i could easily test this out in our jenkins instance.

Should fix part of https://github.com/jenkinsci/pipeline-github-plugin/issues/72 ~~but in order to fully fix it it'd need to support regexes~~.



### Testing done

Set it up locally on our jenkins server and added a trigger, with the following syntax: 
```
triggers {
    issueCommentTrigger('.*test this please.*')
    labelAddedTrigger('test-label')
}
```
and it worked. 

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

