### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/GitHubHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/GitHubHelper.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.pipeline.github;
 
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Job;
 import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMHead;
@@ -16,7 +17,6 @@ import org.jenkinsci.plugins.pipeline.github.client.ExtendedGitHubClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
@@ -36,7 +36,7 @@ public class GitHubHelper {
         // go away
     }
 
-    public static Boolean isAuthorized(@Nonnull final Job<?,?> job, @Nonnull final String User) {
+    public static Boolean isAuthorized(@NonNull final Job<?,?> job, @NonNull final String User) {
         ExtendedGitHubClient client = getGitHubClient(job);
         RepositoryId repository = getRepositoryId(job);
         CollaboratorService collaboratorService = new CollaboratorService(client);
@@ -50,7 +50,7 @@ public class GitHubHelper {
         }
     }
 
-    public static ExtendedGitHubClient getGitHubClient(@Nonnull final Job<?,?> job) {
+    public static ExtendedGitHubClient getGitHubClient(@NonNull final Job<?,?> job) {
         SCMSource scmSource = SCMSource.SourceByItem.findSource(job);
         if (scmSource instanceof GitHubSCMSource) {
             GitHubSCMSource gitHubSource = (GitHubSCMSource) scmSource;
@@ -75,7 +75,7 @@ public class GitHubHelper {
         throw new IllegalArgumentException("Job's SCM is not GitHub.");
     }
 
-    public static RepositoryId getRepositoryId(@Nonnull final Job<?,?> job) {
+    public static RepositoryId getRepositoryId(@NonNull final Job<?,?> job) {
         SCMSource src = SCMSource.SourceByItem.findSource(job);
         if (src instanceof GitHubSCMSource) {
             GitHubSCMSource source = (GitHubSCMSource) src;
@@ -86,7 +86,7 @@ public class GitHubHelper {
         return null;
     }
 
-    public static PullRequestSCMHead getPullRequest(@Nonnull final Job job) throws Exception {
+    public static PullRequestSCMHead getPullRequest(@NonNull final Job job) throws Exception {
         PullRequestSCMHead head = (PullRequestSCMHead) SCMHead.HeadByItem.findHead(job);
         if (head == null) {
             throw new IllegalStateException("Build is not a Pull Request");

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/GitHubPipelineGlobalVariables.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/GitHubPipelineGlobalVariables.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.pipeline.github;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Run;
 import jenkins.scm.api.SCMHead;
@@ -7,7 +8,6 @@ import org.jenkinsci.plugins.github_branch_source.PullRequestSCMHead;
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
 import org.jenkinsci.plugins.workflow.cps.GlobalVariableSet;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -20,7 +20,7 @@ import java.util.LinkedList;
  */
 @Extension
 public class GitHubPipelineGlobalVariables extends GlobalVariableSet {
-    @Nonnull
+    @NonNull
     @Override
     public Collection<GlobalVariable> forRun(final Run<?, ?> run) {
         if (run == null) {

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGlobalVariable.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGlobalVariable.java
@@ -1,10 +1,9 @@
 package org.jenkinsci.plugins.pipeline.github;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Run;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
-
-import javax.annotation.Nonnull;
 
 /**
  * Factory for our {@link PullRequestGroovyObject} instance.
@@ -14,15 +13,15 @@ import javax.annotation.Nonnull;
  */
 public class PullRequestGlobalVariable extends GlobalVariable {
 
-    @Nonnull
+    @NonNull
     @Override
     public String getName() {
         return "pullRequest";
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public Object getValue(@Nonnull final CpsScript script) throws Exception {
+    public Object getValue(@NonNull final CpsScript script) throws Exception {
         final Run<?, ?> build = script.$build();
         if (build == null) {
             throw new IllegalStateException("No associated build");

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/PullRequestGroovyObject.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.pipeline.github;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import groovy.lang.GroovyObjectSupport;
 import hudson.model.Job;
@@ -25,7 +26,6 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
@@ -69,7 +69,7 @@ public class PullRequestGroovyObject extends GroovyObjectSupport implements Seri
     private transient ExtendedCommitService commitService;
     private transient ExtendedMilestoneService milestoneService;
 
-    PullRequestGroovyObject(@Nonnull final Job job) throws Exception {
+    PullRequestGroovyObject(@NonNull final Job job) throws Exception {
         this.job = job;
 
         this.jobId = job.getFullName();

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/GitHubEnvironmentVariablesAction.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/GitHubEnvironmentVariablesAction.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.pipeline.github.trigger;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.EnvironmentContributor;
@@ -10,7 +11,6 @@ import hudson.model.TaskListener;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -52,9 +52,9 @@ public class GitHubEnvironmentVariablesAction extends ParametersAction {
 
         @Override
         @SuppressWarnings("rawtypes")
-        public void buildEnvironmentFor(@Nonnull Run run,
-                                        @Nonnull EnvVars envs,
-                                        @Nonnull TaskListener listener) throws IOException, InterruptedException {
+        public void buildEnvironmentFor(@NonNull Run run,
+                                        @NonNull EnvVars envs,
+                                        @NonNull TaskListener listener) throws IOException, InterruptedException {
 
             GitHubEnvironmentVariablesAction action = run.getAction(GitHubEnvironmentVariablesAction.class);
             if (action != null) {

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/GitHubEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/GitHubEventSubscriber.java
@@ -22,7 +22,7 @@ import org.kohsuke.github.GitHub;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/IssueCommentTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/IssueCommentTrigger.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.pipeline.github.trigger;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Item;
@@ -15,7 +16,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -37,7 +37,7 @@ public class IssueCommentTrigger extends Trigger<WorkflowJob> {
     private final String commentPattern;
 
     @DataBoundConstructor
-    public IssueCommentTrigger(@Nonnull final String commentPattern) {
+    public IssueCommentTrigger(@NonNull final String commentPattern) {
         this.commentPattern = commentPattern;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/LabelAddedTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/LabelAddedTrigger.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.pipeline.github.trigger;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Item;
@@ -15,7 +16,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -37,7 +37,7 @@ public class LabelAddedTrigger extends Trigger<WorkflowJob> {
     private final String labelTriggerPattern;
 
     @DataBoundConstructor
-    public LabelAddedTrigger(@Nonnull final String labelTriggerPattern) {
+    public LabelAddedTrigger(@NonNull final String labelTriggerPattern) {
         this.labelTriggerPattern = labelTriggerPattern;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/PullRequestReviewTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/PullRequestReviewTrigger.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.pipeline.github.trigger;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Item;
@@ -16,8 +17,6 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -26,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
+
 /**
  * An PullRequestApprovalTrigger, to be used from pipeline scripts only.
  *
@@ -47,7 +47,7 @@ public class PullRequestReviewTrigger  extends Trigger<WorkflowJob> {
   }
 
   @DataBoundSetter
-  public void setReviewStates(@Nonnull final String [] reviewStates) {
+  public void setReviewStates(@NonNull final String [] reviewStates) {
       this.reviewStates = Arrays.copyOf(reviewStates, reviewStates.length);
   }
 


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

### Testing done

Confirmed that automated tests pass on Linux with Java 21.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
