### PR TITLE
Fix ClassCastException when SCMSource is not GitHubSCMSource

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/IssueCommentTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/IssueCommentTrigger.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.pipeline.github.trigger;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.triggers.Trigger;
@@ -46,29 +45,42 @@ public class IssueCommentTrigger extends Trigger<WorkflowJob> {
         super.start(project, newInstance);
         // we only care about pull requests
         if (SCMHead.HeadByItem.findHead(project) instanceof PullRequestSCMHead) {
-            DescriptorImpl.jobs
-                    .computeIfAbsent(getKey(project), key -> new HashSet<>())
-                    .add(project);
+            final String key = getKey(project);
+            if (key != null) {
+                DescriptorImpl.jobs
+                        .computeIfAbsent(key, k -> new HashSet<>())
+                        .add(project);
+            }
         }
     }
 
     @Override
     public void stop() {
         if (SCMHead.HeadByItem.findHead(job) instanceof PullRequestSCMHead) {
-            DescriptorImpl.jobs.getOrDefault(getKey(job), Collections.emptySet())
-                    .remove(job);
+            final String key = getKey(job);
+            if (key != null) {
+                DescriptorImpl.jobs.getOrDefault(key, Collections.emptySet())
+                        .remove(job);
+            }
         }
     }
 
-    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private String getKey(final WorkflowJob project) {
-        final GitHubSCMSource scmSource = (GitHubSCMSource) SCMSource.SourceByItem.findSource(project);
-        final PullRequestSCMHead scmHead = (PullRequestSCMHead) SCMHead.HeadByItem.findHead(project);
+        final SCMSource scmSource = SCMSource.SourceByItem.findSource(project);
+        if (!(scmSource instanceof GitHubSCMSource)) {
+            LOG.warn("Job: {} has a non-GitHub SCM source: {}, skipping trigger registration",
+                    project.getFullName(), scmSource != null ? scmSource.getClass().getName() : "null");
+            return null;
+        }
+        final SCMHead scmHead = SCMHead.HeadByItem.findHead(project);
+        if (!(scmHead instanceof PullRequestSCMHead)) {
+            return null;
+        }
 
         return String.format("%s/%s/%d",
-                scmSource.getRepoOwner(),
-                scmSource.getRepository(),
-                scmHead.getNumber()).toLowerCase();
+                ((GitHubSCMSource) scmSource).getRepoOwner(),
+                ((GitHubSCMSource) scmSource).getRepository(),
+                ((PullRequestSCMHead) scmHead).getNumber()).toLowerCase();
     }
 
     public String getCommentPattern() {

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/LabelAddedTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/LabelAddedTrigger.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.pipeline.github.trigger;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.triggers.Trigger;
@@ -46,29 +45,42 @@ public class LabelAddedTrigger extends Trigger<WorkflowJob> {
         super.start(project, newInstance);
         // we only care about pull requests
         if (SCMHead.HeadByItem.findHead(project) instanceof PullRequestSCMHead) {
-            DescriptorImpl.jobs
-                    .computeIfAbsent(getKey(project), key -> new HashSet<>())
-                    .add(project);
+            final String key = getKey(project);
+            if (key != null) {
+                DescriptorImpl.jobs
+                        .computeIfAbsent(key, k -> new HashSet<>())
+                        .add(project);
+            }
         }
     }
 
     @Override
     public void stop() {
         if (SCMHead.HeadByItem.findHead(job) instanceof PullRequestSCMHead) {
-            DescriptorImpl.jobs.getOrDefault(getKey(job), Collections.emptySet())
-                    .remove(job);
+            final String key = getKey(job);
+            if (key != null) {
+                DescriptorImpl.jobs.getOrDefault(key, Collections.emptySet())
+                        .remove(job);
+            }
         }
     }
 
-    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private String getKey(final WorkflowJob project) {
-        final GitHubSCMSource scmSource = (GitHubSCMSource) SCMSource.SourceByItem.findSource(project);
-        final PullRequestSCMHead scmHead = (PullRequestSCMHead) SCMHead.HeadByItem.findHead(project);
+        final SCMSource scmSource = SCMSource.SourceByItem.findSource(project);
+        if (!(scmSource instanceof GitHubSCMSource)) {
+            LOG.warn("Job: {} has a non-GitHub SCM source: {}, skipping trigger registration",
+                    project.getFullName(), scmSource != null ? scmSource.getClass().getName() : "null");
+            return null;
+        }
+        final SCMHead scmHead = SCMHead.HeadByItem.findHead(project);
+        if (!(scmHead instanceof PullRequestSCMHead)) {
+            return null;
+        }
 
         return String.format("%s/%s/%d",
-                scmSource.getRepoOwner(),
-                scmSource.getRepository(),
-                scmHead.getNumber()).toLowerCase();
+                ((GitHubSCMSource) scmSource).getRepoOwner(),
+                ((GitHubSCMSource) scmSource).getRepository(),
+                ((PullRequestSCMHead) scmHead).getNumber()).toLowerCase();
     }
 
     public String getLabelTrigger() {

--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/PullRequestReviewTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/trigger/PullRequestReviewTrigger.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.pipeline.github.trigger;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.triggers.Trigger;
@@ -56,29 +55,42 @@ public class PullRequestReviewTrigger  extends Trigger<WorkflowJob> {
       super.start(project, newInstance);
       // we only care about pull requests
       if (SCMHead.HeadByItem.findHead(project) instanceof PullRequestSCMHead) {
-          DescriptorImpl.jobs
-                  .computeIfAbsent(getKey(project), key -> new HashSet<>())
-                  .add(project);
+          final String key = getKey(project);
+          if (key != null) {
+              DescriptorImpl.jobs
+                      .computeIfAbsent(key, k -> new HashSet<>())
+                      .add(project);
+          }
       }
   }
 
   @Override
   public void stop() {
       if (SCMHead.HeadByItem.findHead(job) instanceof PullRequestSCMHead) {
-          DescriptorImpl.jobs.getOrDefault(getKey(job), Collections.emptySet())
-                  .remove(job);
+          final String key = getKey(job);
+          if (key != null) {
+              DescriptorImpl.jobs.getOrDefault(key, Collections.emptySet())
+                      .remove(job);
+          }
       }
   }
 
-  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
   private String getKey(final WorkflowJob project) {
-      final GitHubSCMSource scmSource = (GitHubSCMSource) SCMSource.SourceByItem.findSource(project);
-      final PullRequestSCMHead scmHead = (PullRequestSCMHead) SCMHead.HeadByItem.findHead(project);
+      final SCMSource scmSource = SCMSource.SourceByItem.findSource(project);
+      if (!(scmSource instanceof GitHubSCMSource)) {
+          LOG.warn("Job: {} has a non-GitHub SCM source: {}, skipping trigger registration",
+                  project.getFullName(), scmSource != null ? scmSource.getClass().getName() : "null");
+          return null;
+      }
+      final SCMHead scmHead = SCMHead.HeadByItem.findHead(project);
+      if (!(scmHead instanceof PullRequestSCMHead)) {
+          return null;
+      }
 
       return String.format("%s/%s/%d",
-              scmSource.getRepoOwner(),
-              scmSource.getRepository(),
-              scmHead.getNumber()).toLowerCase();
+              ((GitHubSCMSource) scmSource).getRepoOwner(),
+              ((GitHubSCMSource) scmSource).getRepository(),
+              ((PullRequestSCMHead) scmHead).getNumber()).toLowerCase();
   }
 
   boolean matches(final String reviewState) {


### PR DESCRIPTION
## Problem

The `getKey()` method in `IssueCommentTrigger`, `LabelAddedTrigger`, and `PullRequestReviewTrigger` performs an unsafe cast of the result of `SCMSource.SourceByItem.findSource()` to `GitHubSCMSource`:

```java
final GitHubSCMSource scmSource = (GitHubSCMSource) SCMSource.SourceByItem.findSource(project);
```

This throws a `ClassCastException` when the source is a `NullSCMSource` (or any other non-GitHub SCM source):

```
java.lang.ClassCastException: class jenkins.scm.impl.NullSCMSource cannot be cast to class org.jenkinsci.plugins.github_branch_source.GitHubSCMSource
    at IssueCommentTrigger.getKey(IssueCommentTrigger.java:65)
    at IssueCommentTrigger.stop(IssueCommentTrigger.java:58)
    at PipelineTriggersJobProperty.stopTriggers(PipelineTriggersJobProperty.java:106)
    at WorkflowJob.addProperty(WorkflowJob.java:199)
    at BranchProjectFactory.decorate(BranchProjectFactory.java:255)
    at MultiBranchProject$SCMEventListenerImpl.processHeadUpdate(MultiBranchProject.java:1685)
```

## Impact

This happens during the `stop()`/`start()` cycle triggered by `MultiBranchProject.processHeadUpdate()` when a push event causes `BranchProjectFactory.decorate()` to call `stopTriggers()`. The exception in `stop()` prevents the trigger from being re-registered in `start()`, **silently removing the job from the `DescriptorImpl.jobs` map**. Subsequent webhook events (issue comments, labels, PR reviews) for that PR are then silently ignored because the key lookup returns an empty set.

This is particularly hard to diagnose because:
- The webhook returns HTTP 200
- No error is logged at the time the webhook is processed (the `handleIssueComment` method just silently returns when the jobs map has no entry for the key)
- The `ClassCastException` happens earlier during the push event processing, not during the comment event

## Fix

Added `instanceof` checks before casting in `getKey()`, returning `null` when the source is not a `GitHubSCMSource`. Callers in `start()` and `stop()` now guard against `null` keys. A warning is logged when a non-GitHub SCM source is encountered to help diagnose similar issues.

The same fix is applied to all three affected trigger classes:
- `IssueCommentTrigger`
- `LabelAddedTrigger`
- `PullRequestReviewTrigger`